### PR TITLE
Fixed templates directory in HelloWorld tutorial

### DIFF
--- a/en/content/how-to-extend-otrs/writing-otrs-application.xml
+++ b/en/content/how-to-extend-otrs/writing-otrs-application.xml
@@ -21,7 +21,7 @@
 Kernel
 Kernel/System
 Kernel/Modules
-Kernel/Output/HTML/Standard
+Kernel/Output/HTML/Templates/Standard
 Kernel/Config
 Kernel/Config/Files
 Kernel/Language
@@ -189,7 +189,7 @@ sub GetHelloWorldText {
         <para>
             <programlisting><![CDATA[
 # --
-# Kernel/Output/HTML/Standard/AgentHelloWorld.tt - overview
+# Kernel/Output/HTML/Templates/Standard/AgentHelloWorld.tt - overview
 # Copyright (C) (year) (name of author) (email of author)
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see


### PR DESCRIPTION
This was keeping me from doing the Hello World tutorial. I used this post http://forums.otterhub.org/viewtopic.php?t=32504#p132276 as the source of the fix.