### PR TITLE
Missing type for NavBar

### DIFF
--- a/en/content/how-to-extend-otrs/writing-otrs-application.xml
+++ b/en/content/how-to-extend-otrs/writing-otrs-application.xml
@@ -105,7 +105,7 @@ Kernel/Language
                         <Item Key="Link">Action=AgentHelloWorld</Item>
                         <Item Key="LinkOption"></Item>
                         <Item Key="NavBar">HelloWorld</Item>
-                        <Item Key="Type"></Item>
+                        <Item Key="Type">Menu</Item>
                         <Item Key="Block"></Item>
                         <Item Key="AccessKey"></Item>
                         <Item Key="Prio">8400</Item>


### PR DESCRIPTION
This example is missing the Type=Menu in the example. Without it, the "HelloWorld" button did not appear in the NavBar