### PR TITLE
Update code-style.rst

### DIFF
--- a/content/contributing/code-style.rst
+++ b/content/contributing/code-style.rst
@@ -390,7 +390,7 @@ You can set a variable to ``''`` if you want to concatenate strings:
 
    my $SqlStatement = '';
    for my $Part (@Parts) {
-       $SqlStatement .= $Part;
+       $SqlStatement = $SqlStatement . $Part;
    }
 
 Otherwise you would get an *uninitialized* warning.


### PR DESCRIPTION
Using `.=` does not give `uninitialized` warning (proof: https://perlbanjo.com/b8ced3b3bc ). Only using `.` gives such warning ( https://perlbanjo.com/dfc7010e34 )